### PR TITLE
Add further sentiment analysis to ChatMessageEvent

### DIFF
--- a/src/components/Match/MatchStory.jsx
+++ b/src/components/Match/MatchStory.jsx
@@ -156,6 +156,22 @@ const formatList = (items, noneValue = []) => {
   }
 };
 
+// evaluate the sentiment behind the message - rage, question, statement etc
+const evaluateSentiment = (message) => {
+  let string_appendature = "normal";
+
+  if (message.split(' ').length > 10) {
+    string_appendature = "long";
+  } else if (message.toUpperCase() === message && /\w/.test(message)) {
+    string_appendature = "shouted";
+  } else if (/(\?|!|@|~|#|\$){2,}/.test(message)) {
+    string_appendature = "excited";
+  }
+  const isQuestion = message.indexOf('?') !== -1;
+
+  return strings[(isQuestion ? 'question_' : 'statement_') + string_appendature];
+};
+
 // Abstract class
 class StoryEvent {
   constructor(time) {
@@ -219,7 +235,7 @@ class ChatMessageEvent extends StoryEvent {
     return formatTemplate(strings.story_chatmessage, {
       player: PlayerSpan(this.player),
       message: this.message,
-      said_verb: (this.message.charAt(this.message.length - 1) === '?') ? strings.story_chat_asked : strings.story_chat_said,
+      said_verb: evaluateSentiment(this.message),
     });
   }
 }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1065,5 +1065,15 @@
   "advb_about": "about",
 
   "article_before_consonant_sound": "a",
-  "article_before_vowel_sound": "an"
+  "article_before_vowel_sound": "an",
+
+  "statement_long": "hypothesised",
+  "statement_shouted": "shouted",
+  "statement_excited": "exclaimed",
+  "statement_normal": "said",
+
+  "question_long": "raised, in need of answers",
+  "question_shouted": "inquired",
+  "question_excited": "interrogated",
+  "question_normal": "asked"
 }


### PR DESCRIPTION
* Added some simple analysis on the message, to make it a little more varied than "said", "asked".
* Moved the strings into the the relevant json - If anyone can translate to other languages that would be good.

![example chat log](https://user-images.githubusercontent.com/8285074/30235563-e9c889da-954c-11e7-9703-8c8f2d52859a.png)
